### PR TITLE
Añade página «Sobre Aldea Pucela»

### DIFF
--- a/_layouts/landing.html
+++ b/_layouts/landing.html
@@ -134,6 +134,7 @@
 
   <!-- Footer with Theme Toggle -->
   <footer class="site-footer">
+    <a href="/sobre/" class="footer-link">Sobre Aldea Pucela</a>
     <button id="theme-toggle" class="theme-toggle" aria-label="Cambiar modo oscuro/claro">
       <i class="fa-regular fa-moon icon-moon" aria-hidden="true"></i>
       <i class="fa-regular fa-sun icon-sun" aria-hidden="true"></i>

--- a/css/styles.css
+++ b/css/styles.css
@@ -1395,6 +1395,21 @@ p {
   /* Spans full width on desktop grid */
   display: flex;
   justify-content: center;
+  align-items: center;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+
+.site-footer .footer-link {
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.site-footer .footer-link:hover {
+  color: var(--text-main);
+  text-decoration: underline;
 }
 
 /* --- Theme Toggle Button (Static Footer Version) --- */

--- a/sobre.html
+++ b/sobre.html
@@ -1,0 +1,23 @@
+---
+layout: page
+title: Sobre Aldea Pucela
+permalink: /sobre/
+slug: sobre
+---
+
+<a href="/" aria-label="Volver a la portada de Aldea Pucela">
+    <img src="/img/logo-web.jpg" class="logo logo-centered" alt="Logo Aldea Pucela">
+</a>
+
+<h1>Sobre Aldea Pucela</h1>
+
+<p>Aldea Pucela es una comunidad formada por vecinos y vecinas de (principalmente) la ciudad de Valladolid y su alfoz, que hoy en día (01/07/2026) cuenta con +6500 personas en su principal canal (<a href="https://t.me/AldeaPucela">Telegram</a>). Además, también tenemos un <a href="https://foro.aldeapucela.org/">Foro</a> donde se organizan temas varios surgidos y creados en el grupo.</p>
+
+<p>La comunidad está organizada y moderada de manera voluntaria y sin ánimo de lucro por tres vecinos de la ciudad @Spacebom, @Nukeador y @Yustin. Somos meros gestores de la infraestructura y la moderación de los distintos espacios de participación y no tenemos responsabilidad directa sobre los contenidos y comportamientos de las personas que conforman y participan en la comunidad. Si necesitas ponerte en contacto con nosotros por algún motivo, puedes hacerlo <a href="https://proyectos.aldeapucela.org/nc/form/a4853f74-d4d4-426e-8e48-d7234f2421c0">desde este formulario</a>.</p>
+
+<p>Además, existen dos tipos de proyectos alojados bajo el dominio y paraguas de la comunidad:</p>
+
+<ul>
+    <li>Por un lado, aquellos que se nutren de contenidos creados y compartidos por los propios participantes de la comunidad como, por ejemplo: Eventos Culturales, Fotos de Valladolid o Negocios Locales.</li>
+    <li>Por otro lado, proyectos que surgen de las inquietudes de participantes de la comunidad como, por ejemplo: Contratos Municipales o Presupuesto Participativos, y que han sido creados a partir de datos públicos por distintos integrantes de la comunidad. Estos proyectos son libres y públicos y su código, licencias, así como las personas que han contribuido en cada uno de ellos se puede consultar en cada uno de los repositorios asociados a cada proyecto en particular: <a href="https://github.com/orgs/aldeapucela/repositories">https://github.com/orgs/aldeapucela/repositories</a></li>
+</ul>


### PR DESCRIPTION
Nueva página `/sobre/` (`sobre.html`) con información sobre la comunidad, enlazada desde el footer de la portada con el texto **«Sobre Aldea Pucela»**.

### Cambios
- **`sobre.html`** — nueva página con el layout `page` (mismo diseño legible que `/normas/`). Incluye el logo de la portada enlazando a la home y el texto sobre la comunidad, gestión, contacto y proyectos.
- **`_layouts/landing.html`** — enlace «Sobre Aldea Pucela» añadido al footer.
- **`css/styles.css`** — espaciado del footer (`gap`/`align-items`/`flex-wrap`) y estilo del enlace `.footer-link`.

Enlaces incluidos: Telegram, Foro, el formulario de contacto y el listado de repositorios de la organización.