### PR TITLE
Centra el contenedor de /sobre/ como en /normas/

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    {% if page.noindex %}<meta name="robots" content="noindex">{% endif %}
     <link rel="icon" type="image/png" href="/img/favicon.png">
     <link rel="stylesheet" href="/css/styles.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" integrity="sha512-Evv84Mr4kqVGRNSgIGL/F/aIDqQb7xQ2vcrdIwxfjThSH8CSR7PBEakCr51Ck+w+/U6swU2Im1vVX0SVk9ABhg==" crossorigin="anonymous" referrerpolicy="no-referrer">

--- a/css/styles.css
+++ b/css/styles.css
@@ -170,7 +170,8 @@ body {
 }
 
 /* Estilo para páginas de texto */
-.page-normas {
+.page-normas,
+.page-sobre {
   text-align: left;
   max-width: 600px;
   margin: 0 auto;

--- a/sobre.html
+++ b/sobre.html
@@ -3,6 +3,7 @@ layout: page
 title: Sobre Aldea Pucela
 permalink: /sobre/
 slug: sobre
+noindex: true
 ---
 
 <a href="/" aria-label="Volver a la portada de Aldea Pucela">
@@ -13,11 +14,11 @@ slug: sobre
 
 <p>Aldea Pucela es una comunidad formada por vecinos y vecinas de (principalmente) la ciudad de Valladolid y su alfoz, que hoy en día (01/07/2026) cuenta con +6500 personas en su principal canal (<a href="https://t.me/AldeaPucela">Telegram</a>). Además, también tenemos un <a href="https://foro.aldeapucela.org/">Foro</a> donde se organizan temas varios surgidos y creados en el grupo.</p>
 
-<p>La comunidad está organizada y moderada de manera voluntaria y sin ánimo de lucro por tres vecinos de la ciudad @Spacebom, @Nukeador y @Yustin. Somos meros gestores de la infraestructura y la moderación de los distintos espacios de participación y no tenemos responsabilidad directa sobre los contenidos y comportamientos de las personas que conforman y participan en la comunidad. Si necesitas ponerte en contacto con nosotros por algún motivo, puedes hacerlo <a href="https://proyectos.aldeapucela.org/nc/form/a4853f74-d4d4-426e-8e48-d7234f2421c0">desde este formulario</a>.</p>
-
 <p>Además, existen dos tipos de proyectos alojados bajo el dominio y paraguas de la comunidad:</p>
 
 <ul>
     <li>Por un lado, aquellos que se nutren de contenidos creados y compartidos por los propios participantes de la comunidad como, por ejemplo: Eventos Culturales, Fotos de Valladolid o Negocios Locales.</li>
     <li>Por otro lado, proyectos que surgen de las inquietudes de participantes de la comunidad como, por ejemplo: Contratos Municipales o Presupuesto Participativos, y que han sido creados a partir de datos públicos por distintos integrantes de la comunidad. Estos proyectos son libres y públicos y su código, licencias, así como las personas que han contribuido en cada uno de ellos se puede consultar en cada uno de los repositorios asociados a cada proyecto en particular: <a href="https://github.com/orgs/aldeapucela/repositories">https://github.com/orgs/aldeapucela/repositories</a></li>
 </ul>
+
+<p>La comunidad está organizada y moderada de manera voluntaria y sin ánimo de lucro por tres vecinos de la ciudad (@Spacebom, @Nukeador y @Yustin). Somos meros gestores de la infraestructura y la moderación de los distintos espacios de participación y no tenemos responsabilidad directa sobre los contenidos y comportamientos de las personas que conforman y participan en la comunidad. Si necesitas ponerte en contacto con nosotros por algún motivo, puedes hacerlo <a href="https://proyectos.aldeapucela.org/nc/form/a4853f74-d4d4-426e-8e48-d7234f2421c0">desde este formulario</a>.</p>


### PR DESCRIPTION
El commit del centrado se quedó fuera del #2 (se mergeó antes de que entrara). Este PR aplica solo ese cambio: añade `.page-sobre` a la regla `.page-normas` para que `/sobre/` use el mismo contenedor centrado de 600px.