### PR TITLE
Añade Peluditos al menú de la portada

### DIFF
--- a/_layouts/landing.html
+++ b/_layouts/landing.html
@@ -44,6 +44,13 @@
           <span>Eventos culturales</span>
         </a>
 
+        <a href="https://peluditos.aldeapucela.org/" class="feature-card">
+          <div class="card-icon card-icon-peluditos">
+            <i class="fa-solid fa-paw" aria-hidden="true"></i>
+          </div>
+          <span>Peluditos</span>
+        </a>
+
         <a href="https://otrapucela.org" class="feature-card">
           <div class="card-icon card-icon-otra-pucela">
             <i class="fa-regular fa-newspaper" aria-hidden="true"></i>

--- a/css/styles.css
+++ b/css/styles.css
@@ -745,7 +745,8 @@ p {
 .card-icon-negocios,
 .card-icon-archivo,
 .card-icon-bluesky,
-.card-icon-participa {
+.card-icon-participa,
+.card-icon-peluditos {
   color: #5B4A78;
 }
 
@@ -764,7 +765,8 @@ p {
 [data-theme="dark"] .card-icon-negocios,
 [data-theme="dark"] .card-icon-archivo,
 [data-theme="dark"] .card-icon-bluesky,
-[data-theme="dark"] .card-icon-participa {
+[data-theme="dark"] .card-icon-participa,
+[data-theme="dark"] .card-icon-peluditos {
   color: #C7BDE0;
 }
 


### PR DESCRIPTION
Nueva tarjeta **Peluditos** en el grid de la portada, justo debajo de «Eventos culturales», enlazando a https://peluditos.aldeapucela.org/ (agregador de protectoras y adopciones de Valladolid).

- Icono `fa-paw` (pata).
- `card-icon-peluditos` reutiliza el grupo de color morado existente (claro/oscuro), sin CSS de color nuevo.