### PR TITLE
Los enlaces del menú se abren en pestaña nueva

### DIFF
--- a/_layouts/landing.html
+++ b/_layouts/landing.html
@@ -37,98 +37,98 @@
     <div class="container">
       <div class="features-grid">
 
-        <a href="https://eventos.aldeapucela.org" class="feature-card">
+        <a href="https://eventos.aldeapucela.org" class="feature-card" target="_blank" rel="noopener">
           <div class="card-icon card-icon-eventos">
             <i class="fa-regular fa-calendar-days" aria-hidden="true"></i>
           </div>
           <span>Eventos culturales</span>
         </a>
 
-        <a href="https://peluditos.aldeapucela.org/" class="feature-card">
+        <a href="https://peluditos.aldeapucela.org/" class="feature-card" target="_blank" rel="noopener">
           <div class="card-icon card-icon-peluditos">
             <i class="fa-solid fa-paw" aria-hidden="true"></i>
           </div>
           <span>Peluditos</span>
         </a>
 
-        <a href="https://otrapucela.org" class="feature-card">
+        <a href="https://otrapucela.org" class="feature-card" target="_blank" rel="noopener">
           <div class="card-icon card-icon-otra-pucela">
             <i class="fa-regular fa-newspaper" aria-hidden="true"></i>
           </div>
           <span>La Otra Pucela</span>
         </a>
 
-        <a href="https://contratos.aldeapucela.org" class="feature-card">
+        <a href="https://contratos.aldeapucela.org" class="feature-card" target="_blank" rel="noopener">
           <div class="card-icon card-icon-contratos">
             <i class="fa-regular fa-file-lines" aria-hidden="true"></i>
           </div>
           <span>Contratos municipales</span>
         </a>
 
-        <a href="https://participa.aldeapucela.org" class="feature-card">
+        <a href="https://participa.aldeapucela.org" class="feature-card" target="_blank" rel="noopener">
           <div class="card-icon card-icon-participa">
             <i class="fa-solid fa-bullhorn" aria-hidden="true"></i>
           </div>
           <span>Campañas vecinales</span>
         </a>
 
-        <a href="https://fotos.aldeapucela.org" class="feature-card">
+        <a href="https://fotos.aldeapucela.org" class="feature-card" target="_blank" rel="noopener">
           <div class="card-icon card-icon-fotos">
             <i class="fa-solid fa-camera-retro" aria-hidden="true"></i>
           </div>
           <span>Fotos de Valladolid</span>
         </a>
 
-        <a href="https://negocios.aldeapucela.org" class="feature-card">
+        <a href="https://negocios.aldeapucela.org" class="feature-card" target="_blank" rel="noopener">
           <div class="card-icon card-icon-negocios">
             <i class="fa-solid fa-store" aria-hidden="true"></i>
           </div>
           <span>Negocios locales</span>
         </a>
 
-        <a href="https://creators.spotify.com/pod/show/aldea-pucela" class="feature-card">
+        <a href="https://creators.spotify.com/pod/show/aldea-pucela" class="feature-card" target="_blank" rel="noopener">
           <div class="card-icon card-icon-podcast">
             <i class="fa-solid fa-podcast" aria-hidden="true"></i>
           </div>
           <span>Podcasts</span>
         </a>
 
-        <a href="https://video.aldeapucela.org" class="feature-card">
+        <a href="https://video.aldeapucela.org" class="feature-card" target="_blank" rel="noopener">
           <div class="card-icon card-icon-videos">
             <i class="fa-solid fa-video" aria-hidden="true"></i>
           </div>
           <span>Vídeos</span>
         </a>
 
-        <a href="/archivo/" class="feature-card">
+        <a href="/archivo/" class="feature-card" target="_blank" rel="noopener">
           <div class="card-icon card-icon-archivo">
             <i class="fa-solid fa-box-archive" aria-hidden="true"></i>
           </div>
           <span>Archivo Chat</span>
         </a>
 
-        <a href="https://presupuestos.aldeapucela.org/" class="feature-card">
+        <a href="https://presupuestos.aldeapucela.org/" class="feature-card" target="_blank" rel="noopener">
           <div class="card-icon card-icon-presupuestos">
             <i class="fa-solid fa-landmark" aria-hidden="true"></i>
           </div>
           <span>Presupuestos participativos 2027</span>
         </a>
 
-        <a href="https://aldeapucela.org/integracion/" class="feature-card">
+        <a href="https://aldeapucela.org/integracion/" class="feature-card" target="_blank" rel="noopener">
           <div class="card-icon card-icon-integracion">
             <i class="fa-solid fa-train-subway" aria-hidden="true"></i>
           </div>
           <span>Plataforma Integración Ferroviaria</span>
         </a>
 
-        <a href="/normas/" class="feature-card">
+        <a href="/normas/" class="feature-card" target="_blank" rel="noopener">
           <div class="card-icon card-icon-normas">
             <i class="fa-solid fa-circle-info" aria-hidden="true"></i>
           </div>
           <span>Normas</span>
         </a>
 
-        <a href="https://bsky.app/profile/pucelobot.aldeapucela.org" class="feature-card">
+        <a href="https://bsky.app/profile/pucelobot.aldeapucela.org" class="feature-card" target="_blank" rel="noopener">
           <div class="card-icon card-icon-bluesky">
             <i class="fa-solid fa-robot" aria-hidden="true"></i>
           </div>


### PR DESCRIPTION
Añade `target="_blank"` a las 14 tarjetas del menú de la portada para que abran en una pestaña nueva. Incluye `rel="noopener"` (seguridad estándar; sin `noreferrer` para conservar el referer de Matomo).