### PR TITLE
Corregir texto del botón Telegram en tema oscuro (azul → mint esmeralda)

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -826,7 +826,7 @@ p {
 [data-theme="dark"] .hero-telegram-trigger .btn-secondary {
   background: rgba(30, 158, 138, 0.16);
   border-color: rgba(30, 158, 138, 0.30);
-  color: #A8D2F4;
+  color: #8FE3D0;
 }
 
 .hero-telegram-trigger .btn-secondary:hover {


### PR DESCRIPTION
El texto del botón "Grupo en Telegram" en tema oscuro seguía en azul claro `#A8D2F4`, un resto hardcodeado del color secundario antiguo que no usaba la variable `--color-secondary`.

Pasa a mint claro **`#8FE3D0`**, acorde al nuevo secundario esmeralda (`#1E9E8A`) del PR #6.

Cambio de una sola línea en `css/styles.css` (regla `[data-theme="dark"] .hero-telegram-trigger .btn-secondary`).